### PR TITLE
Support none user

### DIFF
--- a/src/pytest_keyring/pytest_keyring.py
+++ b/src/pytest_keyring/pytest_keyring.py
@@ -143,7 +143,7 @@ def pytest_collection_modifyitems(
             elif fixture_name.startswith(password_prefix):
                 if len(fixture_name.split("_", maxsplit=2)) == 2:
                     _, service_name = fixture_name.split("_", maxsplit=1)
-                    username = None
+                    username = keyring.get_credential(service_name, None).username
                 else:
                     _, service_name, username = fixture_name.split("_", maxsplit=2)
 

--- a/src/pytest_keyring/pytest_keyring.py
+++ b/src/pytest_keyring/pytest_keyring.py
@@ -117,7 +117,12 @@ def pytest_collection_modifyitems(
                 continue
 
             if fixture_name.startswith(credential_prefix):
-                _, service_name, username = fixture_name.split("_", maxsplit=2)
+                if len(fixture_name.split("_", maxsplit=2)) == 2:
+                    _, service_name = fixture_name.split("_", maxsplit=1)
+                    username = None
+                else:
+                    _, service_name, username = fixture_name.split("_", maxsplit=2)
+
                 credential = keyring.get_credential(service_name, username)
 
                 def fixture_credential_func() -> keyring.credentials.Credential | None:
@@ -136,7 +141,12 @@ def pytest_collection_modifyitems(
                 ]
 
             elif fixture_name.startswith(password_prefix):
-                _, service_name, username = fixture_name.split("_", maxsplit=2)
+                if len(fixture_name.split("_", maxsplit=2)) == 2:
+                    _, service_name = fixture_name.split("_", maxsplit=1)
+                    username = None
+                else:
+                    _, service_name, username = fixture_name.split("_", maxsplit=2)
+
                 password = keyring.get_password(service_name, username)
 
                 def fixture_password_func() -> str | None:

--- a/tests/test_pytest_keyring.py
+++ b/tests/test_pytest_keyring.py
@@ -35,12 +35,40 @@ def test_get_credential(pytester):
     result.assert_outcomes(passed=1)
 
 
+def test_get_credential_without_username(pytester):
+    """Test get_credential."""
+    pytester.makepyfile(
+        """
+        def test_get_credential(credential_database):
+            assert credential_database.password == "pass"
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+
+
 def test_get_password(pytester):
     """Test get_password."""
     pytester.makepyfile(
         """
         def test_get_password(password_database_username):
             assert password_database_username == "pass"
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+
+
+def test_get_password_without_username(pytester):
+    """Test get_password."""
+    pytester.makepyfile(
+        """
+        def test_get_password(password_database):
+            assert password_database == "pass"
         """
     )
 


### PR DESCRIPTION
Keyring lib supports get_credentials without username. This is useful if you have usernames like RID-test. In pytest-keyring the fixture name looks like credential_servicename_RID-test and throws an exception. This PR makes it possible just to use service name and skip usernames at all.