### PR TITLE
fix: Backwards compatibility support for optional return types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "pytest-keyring"
-version = "1.1.2"
+version = "1.1.3"
 description = "A Pytest plugin to access the system's keyring to provide credentials for tests"
 readme = "README.md"
 keywords = [ "keyring", "pytest", "pytest-plugin" ]

--- a/src/pytest_keyring/pytest_keyring.py
+++ b/src/pytest_keyring/pytest_keyring.py
@@ -10,11 +10,13 @@ class KeyringProtocol(typing.Protocol):
 
     def delete_password(self, service_name: str, username: str) -> None: ...
 
-    def get_password(self, service_name: str, username: str) -> str | None: ...
+    def get_password(
+        self, service_name: str, username: str
+    ) -> typing.Optional[str]: ...
 
     def get_credential(
         self, service_name: str, username: typing.Optional[str]
-    ) -> keyring.credentials.Credential | None: ...
+    ) -> typing.Optional[keyring.credentials.Credential]: ...
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -121,7 +123,9 @@ def pytest_collection_modifyitems(
 
                 credential = keyring.get_credential(service_name, username)
 
-                def fixture_credential_func() -> keyring.credentials.Credential | None:
+                def fixture_credential_func() -> typing.Optional[
+                    keyring.credentials.Credential
+                ]:
                     """Define a function for the dynamic fixture."""
                     return credential
 
@@ -148,7 +152,7 @@ def pytest_collection_modifyitems(
 
                 password = keyring.get_password(service_name, username)
 
-                def fixture_password_func() -> str | None:
+                def fixture_password_func() -> typing.Optional[str]:
                     """Define a function for the dynamic fixture."""
                     return password
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-27T12:24:18.332252899Z"
+exclude-newer = "2026-03-27T12:32:49.059611953Z"
 exclude-newer-span = "P14D"
 
 [[package]]
@@ -1373,7 +1373,7 @@ wheels = [
 
 [[package]]
 name = "pytest-keyring"
-version = "1.1.1"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "keyring", version = "25.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
Ugh, accidentally broke <=3.9 support due to the `| None` syntax not being available. I need to setup some CI here to catch errors like that, I was lazy and didn't run tox.